### PR TITLE
fix for ldap

### DIFF
--- a/conf/local.yaml
+++ b/conf/local.yaml
@@ -10,6 +10,7 @@ kimai:
     user:
         registration: __REGISTRATION__
     ldap:
+        activate: true
         # more infos about the connection params can be found at:
         # https://docs.laminas.dev/laminas-ldap/api/
         connection:
@@ -109,7 +110,7 @@ kimai:
             attributes:
                 # The following 2 rules are automatically prepended and can be overwritten.
                 # Username is set to the value of the configured "usernameAttribute" field 
-                - { ldap_attr: "usernameAttribute", user_method: setUsername }
+                - { ldap_attr: "uid", user_method: setUsername }
                 # Only applied if you don't configure a mapping for setEmail()
                 - { ldap_attr: mail, user_method: setEmail }
                 # An example which will set the display name in Kimai from the 


### PR DESCRIPTION
## Problem

- after installing kimai2 in yuno, the ldap user from yuno were not able to login. 

## Solution

- in the actual version there has to be a "activate: true" tag within the ldap config in the local.yaml

## PR Status

- [X] Code finished and ready to be reviewed/tested
- [X] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
