### PR TITLE
Fix duplicate path for "security.firewalls"

### DIFF
--- a/conf/local.yaml
+++ b/conf/local.yaml
@@ -1,11 +1,3 @@
-security:
-    providers:
-        chain_provider:
-            chain:
-                providers: [kimai_ldap]
-    firewalls:
-        secured_area:
-            kimai_ldap: ~
 kimai:
     user:
         registration: __REGISTRATION__


### PR DESCRIPTION
## Problem
Upgrade tests are failing, see here: https://ci-apps-dev.yunohost.org/ci/job/9479

Issue is in symfony framework, see https://github.com/symfony/symfony/issues/22308 and https://github.com/symfony/symfony/issues/25021. 2nd issue also referenced by Kevin Papst (lead developer of kimai) some time ago.

## Solution
A security block (including firewall) is already included in `security.yaml`, see https://github.com/kimai/kimai/blob/main/config/packages/security.yaml . Thus, it must not be defined in `local.yaml` again. Solution: Remove duplicate security block from `local.yaml`.

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
