### PR TITLE
Upgrade PHP version to 8.2

### DIFF
--- a/ALL_README.md
+++ b/ALL_README.md
@@ -1,6 +1,7 @@
 # All available README files by language
 
 - [Read the README in English](README.md)
+- [Lea el README en español](README_es.md)
 - [Irakurri README euskaraz](README_eu.md)
 - [Lire le README en français](README_fr.md)
 - [Le o README en galego](README_gl.md)

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ It shall NOT be edited by hand.
 Kimai v2 has nothing in common with its predecessor Kimai v1 besides the basic ideas of time-tracking and the current development team. It is based on a lot of great frameworks. Special thanks to Symfony v4, Doctrine, AdminThemeBundle (based on AdminLTE).
 
 
-**Shipped version:** 2.16.1~ynh1
+**Shipped version:** 2.17.0~ynh1
 
 **Demo:** <https://www.kimai.org/demo/>
 

--- a/README_es.md
+++ b/README_es.md
@@ -1,0 +1,50 @@
+<!--
+Este archivo README esta generado automaticamente<https://github.com/YunoHost/apps/tree/master/tools/readme_generator>
+No se debe editar a mano.
+-->
+
+# Kimai2 para Yunohost
+
+[![Nivel de integración](https://dash.yunohost.org/integration/kimai2.svg)](https://dash.yunohost.org/appci/app/kimai2) ![Estado funcional](https://ci-apps.yunohost.org/ci/badges/kimai2.status.svg) ![Estado En Mantención](https://ci-apps.yunohost.org/ci/badges/kimai2.maintain.svg)
+
+[![Instalar Kimai2 con Yunhost](https://install-app.yunohost.org/install-with-yunohost.svg)](https://install-app.yunohost.org/?app=kimai2)
+
+*[Leer este README en otros idiomas.](./ALL_README.md)*
+
+> *Este paquete le permite instalarKimai2 rapidamente y simplement en un servidor YunoHost.*  
+> *Si no tiene YunoHost, visita [the guide](https://yunohost.org/install) para aprender como instalarla.*
+
+## Descripción general
+
+Kimai v2 has nothing in common with its predecessor Kimai v1 besides the basic ideas of time-tracking and the current development team. It is based on a lot of great frameworks. Special thanks to Symfony v4, Doctrine, AdminThemeBundle (based on AdminLTE).
+
+
+**Versión actual:** 2.17.0~ynh1
+
+**Demo:** <https://www.kimai.org/demo/>
+
+## Capturas
+
+![Captura de Kimai2](./doc/screenshots/screenshot1.png)
+
+## Documentaciones y recursos
+
+- Sitio web oficial: <https://www.kimai.org>
+- Documentación administrador oficial: <https://www.kimai.org/documentation/>
+- Repositorio del código fuente oficial de la aplicación : <https://github.com/kevinpapst/kimai2>
+- Catálogo YunoHost: <https://apps.yunohost.org/app/kimai2>
+- Reportar un error: <https://github.com/YunoHost-Apps/kimai2_ynh/issues>
+
+## Información para desarrolladores
+
+Por favor enviar sus correcciones a la [`branch testing`](https://github.com/YunoHost-Apps/kimai2_ynh/tree/testing
+
+Para probar la rama `testing`, sigue asÍ:
+
+```bash
+sudo yunohost app install https://github.com/YunoHost-Apps/kimai2_ynh/tree/testing --debug
+o
+sudo yunohost app upgrade kimai2 -u https://github.com/YunoHost-Apps/kimai2_ynh/tree/testing --debug
+```
+
+**Mas informaciones sobre el empaquetado de aplicaciones:** <https://yunohost.org/packaging_apps>

--- a/README_eu.md
+++ b/README_eu.md
@@ -19,7 +19,7 @@ EZ editatu eskuz.
 Kimai v2 has nothing in common with its predecessor Kimai v1 besides the basic ideas of time-tracking and the current development team. It is based on a lot of great frameworks. Special thanks to Symfony v4, Doctrine, AdminThemeBundle (based on AdminLTE).
 
 
-**Paketatutako bertsioa:** 2.16.1~ynh1
+**Paketatutako bertsioa:** 2.17.0~ynh1
 
 **Demoa:** <https://www.kimai.org/demo/>
 

--- a/README_fr.md
+++ b/README_fr.md
@@ -19,7 +19,7 @@ Il NE doit PAS être modifié à la main.
 Kimai v2 has nothing in common with its predecessor Kimai v1 besides the basic ideas of time-tracking and the current development team. It is based on a lot of great frameworks. Special thanks to Symfony v4, Doctrine, AdminThemeBundle (based on AdminLTE).
 
 
-**Version incluse :** 2.16.1~ynh1
+**Version incluse :** 2.17.0~ynh1
 
 **Démo :** <https://www.kimai.org/demo/>
 

--- a/README_gl.md
+++ b/README_gl.md
@@ -19,7 +19,7 @@ NON debe editarse manualmente.
 Kimai v2 has nothing in common with its predecessor Kimai v1 besides the basic ideas of time-tracking and the current development team. It is based on a lot of great frameworks. Special thanks to Symfony v4, Doctrine, AdminThemeBundle (based on AdminLTE).
 
 
-**Versión proporcionada:** 2.16.1~ynh1
+**Versión proporcionada:** 2.17.0~ynh1
 
 **Demo:** <https://www.kimai.org/demo/>
 

--- a/README_zh_Hans.md
+++ b/README_zh_Hans.md
@@ -19,7 +19,7 @@
 Kimai v2 has nothing in common with its predecessor Kimai v1 besides the basic ideas of time-tracking and the current development team. It is based on a lot of great frameworks. Special thanks to Symfony v4, Doctrine, AdminThemeBundle (based on AdminLTE).
 
 
-**分发版本：** 2.16.1~ynh1
+**分发版本：** 2.17.0~ynh1
 
 **演示：** <https://www.kimai.org/demo/>
 

--- a/manifest.toml
+++ b/manifest.toml
@@ -9,7 +9,7 @@ description.fr = "Application multi-utilisateurs de suivi du temps compatible av
 description.de = "Eine web-basierte Mehrbenutzer-Zeiterfassung mit Rechnungsdruck mit Unterstützung für mobile Endgeräte"
 description.cs = "Víceuživatelská webová aplikace pro sledování času s podporou mobilních zařízení"
 
-version = "2.16.1~ynh1"
+version = "2.17.0~ynh1"
 
 maintainers = []
 
@@ -55,8 +55,8 @@ ram.runtime = "80M"
 
 [resources]
     [resources.sources.main]
-    url = "https://github.com/kevinpapst/kimai2/archive/refs/tags/2.16.1.tar.gz"
-    sha256 = "77c3b470c82552eddaf4da962def94a201d0a60b34bd6cd91128ecc149f59ac5"
+    url = "https://github.com/kevinpapst/kimai2/archive/refs/tags/2.17.0.tar.gz"
+    sha256 = "354a308c513f0bf0296b5acd15733a14940657f7ee0c460c721ce7e3a168cd52"
 
     autoupdate.strategy = "latest_github_tag"
 

--- a/manifest.toml
+++ b/manifest.toml
@@ -77,17 +77,17 @@ ram.runtime = "80M"
 
     [resources.apt]
     packages = [
-        "php8.1-gd",
-        "php8.1-intl",
-        "php8.1-json",
-        "php8.1-mbstring",
-        "php8.1-pdo",
-        "php8.1-zip",
-        "php8.1-xml",
-        "php8.1-xsl",
-        "php8.1-ldap",
-        "php8.1-mysql",
-        "php8.1-sqlite3",
+        "php8.2-gd",
+        "php8.2-intl",
+        "php8.2-json",
+        "php8.2-mbstring",
+        "php8.2-pdo",
+        "php8.2-zip",
+        "php8.2-xml",
+        "php8.2-xsl",
+        "php8.2-ldap",
+        "php8.2-mysql",
+        "php8.2-sqlite3",
         "mariadb-server",
     ]
 


### PR DESCRIPTION
## Problem

PHP 8.1 active support has ended 6 months ago. See https://www.php.net/supported-versions.php.

## Solution

Upgrade to PHP 8.2 which is officially supported by Kimai.

> Compatible with PHP 8.1 to 8.3

See https://github.com/kimai/kimai/releases/tag/2.17.0.

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
