### PR TITLE
Upgrade PHP version to 8.3

### DIFF
--- a/manifest.toml
+++ b/manifest.toml
@@ -77,17 +77,17 @@ ram.runtime = "80M"
 
     [resources.apt]
     packages = [
-        "php8.2-gd",
-        "php8.2-intl",
-        "php8.2-json",
-        "php8.2-mbstring",
-        "php8.2-pdo",
-        "php8.2-zip",
-        "php8.2-xml",
-        "php8.2-xsl",
-        "php8.2-ldap",
-        "php8.2-mysql",
-        "php8.2-sqlite3",
+        "php8.3-gd",
+        "php8.3-intl",
+        "php8.3-json",
+        "php8.3-mbstring",
+        "php8.3-pdo",
+        "php8.3-zip",
+        "php8.3-xml",
+        "php8.3-xsl",
+        "php8.3-ldap",
+        "php8.3-mysql",
+        "php8.3-sqlite3",
         "mariadb-server",
     ]
 


### PR DESCRIPTION
## Problem

PHP 8.3 is more recent than PHP 8.2.

## Solution

Upgrade to PHP 8.3 which is officially supported by Kimai.

> Compatible with PHP 8.1 to 8.3

See https://github.com/kimai/kimai/releases/tag/2.18.0.


## PR Status

- [x] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
